### PR TITLE
Feat: agencia Canteras seleccionable para envíos a Canarias (Nesto#359 MVP)

### DIFF
--- a/Nesto.ViewModels/Agencias/AgenciaCanteras.vb
+++ b/Nesto.ViewModels/Agencias/AgenciaCanteras.vb
@@ -1,0 +1,159 @@
+Imports System.Collections.ObjectModel
+Imports System.Windows
+Imports Nesto.Models
+Imports Nesto.Models.Nesto.Models
+
+' Nesto#359: Canteras es la agencia que hace los envíos a Canarias. No tiene integración
+' (ni web service, ni impresión de etiquetas): el flujo es 100% manual — se les manda un
+' correo con los datos del envío y nos contestan con el nº de envío, que el usuario tiene
+' que pegar en el campo CodigoBarras desde la pestaña de envíos. La validación de mínimos
+' (400€ pedido o 100€ portes) y la prohibición de contra reembolso se hacen en NestoAPI
+' al crear la etiqueta (NestoAPI#204).
+Public Class AgenciaCanteras
+    Implements IAgencia
+
+    Public Sub New()
+        ListaTiposRetorno = New ObservableCollection(Of tipoIdDescripcion) From {
+            New tipoIdDescripcion(0, "NO")
+        }
+        ListaServicios = New ObservableCollection(Of ITarifaAgencia)
+        ListaHorarios = New ObservableCollection(Of tipoIdDescripcion) From {
+            New tipoIdDescripcion(0, "")
+        }
+        ListaPaises = rellenarPaises()
+    End Sub
+
+    Public ReadOnly Property NumeroCliente As String Implements IAgencia.NumeroCliente
+        Get
+            Return String.Empty
+        End Get
+    End Property
+
+    Public Function cargarEstado(envio As EnviosAgencia) As XDocument Implements IAgencia.cargarEstado
+        Throw New Exception("Canteras no permite integración. Consulta el estado por correo con Canteras o usa el nº de envío que indicaron.")
+    End Function
+
+    Public Function transformarXMLdeEstado(envio As XDocument) As estadoEnvio Implements IAgencia.transformarXMLdeEstado
+        Return If(IsNothing(envio), Nothing, New estadoEnvio)
+    End Function
+
+    Public Function calcularCodigoBarras(agenciaVM As AgenciasViewModel) As String Implements IAgencia.calcularCodigoBarras
+        ' Canteras devuelve el nº de envío por correo. El usuario lo pega manualmente; el
+        ' cálculo automático no aplica.
+        Return String.Empty
+    End Function
+
+    Public Sub calcularPlaza(ByVal codPostal As String, ByRef nemonico As String, ByRef nombrePlaza As String, ByRef telefonoPlaza As String, ByRef emailPlaza As String) Implements IAgencia.calcularPlaza
+        nemonico = "CN"
+        nombrePlaza = "Canteras"
+        telefonoPlaza = String.Empty
+        emailPlaza = String.Empty
+    End Sub
+
+    Public Function LlamadaWebService(envio As EnviosAgencia, servicio As IAgenciaService) As Task(Of RespuestaAgencia) Implements IAgencia.LlamadaWebService
+        ' Sin integración. Mismo patrón que OnTime: devolvemos "OK" para que la máquina de
+        ' estados de Agencias avance, pero el tramitado real lo hace el usuario por correo.
+        Dim respuesta As New RespuestaAgencia With {
+            .Agencia = "Canteras",
+            .Fecha = Date.Now,
+            .UrlLlamada = String.Empty,
+            .Exito = True,
+            .CuerpoLlamada = String.Empty,
+            .CuerpoRespuesta = String.Empty,
+            .TextoRespuestaError = "OK"
+        }
+        Return Task.FromResult(Of RespuestaAgencia)(respuesta)
+    End Function
+
+    Public Sub imprimirEtiqueta(envio As EnviosAgencia) Implements IAgencia.imprimirEtiqueta
+        ' Canteras no imprime etiquetas en local — la etiqueta viaja con el correo a Canteras.
+        Throw New Exception("Canteras no genera etiqueta desde Nesto. El envío se notifica por correo.")
+    End Sub
+
+    Public ReadOnly Property visibilidadSoloImprimir As Visibility Implements IAgencia.visibilidadSoloImprimir
+        Get
+            Return Visibility.Collapsed
+        End Get
+    End Property
+
+    Public ReadOnly Property retornoSoloCobros As Byte Implements IAgencia.retornoSoloCobros
+        Get
+            Return 0 ' NO (Canteras no admite contra reembolso)
+        End Get
+    End Property
+
+    Public ReadOnly Property servicioSoloCobros As Byte Implements IAgencia.servicioSoloCobros
+        Get
+            Return 0
+        End Get
+    End Property
+
+    Public ReadOnly Property horarioSoloCobros As Byte Implements IAgencia.horarioSoloCobros
+        Get
+            Return 0
+        End Get
+    End Property
+
+    Public ReadOnly Property retornoSinRetorno As Byte Implements IAgencia.retornoSinRetorno
+        Get
+            Return 0 ' NO
+        End Get
+    End Property
+
+    Public ReadOnly Property retornoObligatorio As Byte Implements IAgencia.retornoObligatorio
+        Get
+            Return 0 ' NO
+        End Get
+    End Property
+
+    Public ReadOnly Property paisDefecto As Integer Implements IAgencia.paisDefecto
+        Get
+            Return 34 ' España (Canarias)
+        End Get
+    End Property
+
+    Private Function rellenarPaises() As ObservableCollection(Of Pais)
+        Return New ObservableCollection(Of Pais) From {
+            New Pais(34, "ESPAÑA")
+        }
+    End Function
+
+    Private Function IAgencia_EnlaceSeguimiento(envio As EnviosAgencia) As String Implements IAgencia.EnlaceSeguimiento
+        ' Canteras no tiene web de tracking; el usuario consulta el estado por correo.
+        Return String.Empty
+    End Function
+
+    Public Function RespuestaYaTramitada(respuesta As String) As Boolean Implements IAgencia.RespuestaYaTramitada
+        Return False
+    End Function
+
+    Public ReadOnly Property ListaPaises As ObservableCollection(Of Pais) Implements IAgencia.ListaPaises
+    Public ReadOnly Property ListaTiposRetorno As ObservableCollection(Of tipoIdDescripcion) Implements IAgencia.ListaTiposRetorno
+    Public ReadOnly Property ListaServicios As ObservableCollection(Of ITarifaAgencia) Implements IAgencia.ListaServicios
+    Public ReadOnly Property ListaHorarios As ObservableCollection(Of tipoIdDescripcion) Implements IAgencia.ListaHorarios
+
+    Public ReadOnly Property ServicioDefecto As Byte Implements IAgencia.ServicioDefecto
+        Get
+            Return 0
+        End Get
+    End Property
+
+    Public ReadOnly Property HorarioDefecto As Byte Implements IAgencia.HorarioDefecto
+        Get
+            Return 0
+        End Get
+    End Property
+
+    Public ReadOnly Property ServicioAuxiliar As Byte Implements IAgencia.ServicioAuxiliar
+        Get
+            Return Byte.MaxValue
+        End Get
+    End Property
+
+    Public ReadOnly Property ServicioCreaEtiquetaRetorno As Byte Implements IAgencia.ServicioCreaEtiquetaRetorno
+        Get
+            Return Byte.MaxValue
+        End Get
+    End Property
+
+End Class

--- a/Nesto.ViewModels/AgenciasViewModel.vb
+++ b/Nesto.ViewModels/AgenciasViewModel.vb
@@ -99,6 +99,7 @@ Public Class AgenciasViewModel
         'factory.Add("Glovo", Function() New AgenciaGlovo(Me))
         factory.Add("Correos Express", Function() New AgenciaCorreosExpress())
         factory.Add("Sending", Function() New AgenciaSending())
+        factory.Add("Canteras", Function() New AgenciaCanteras()) ' Nesto#359: envíos manuales a Canarias
 
 
     End Sub

--- a/ViewModels.Tests/AgenciasViewModelTests.vb
+++ b/ViewModels.Tests/AgenciasViewModelTests.vb
@@ -1099,5 +1099,45 @@ Public Class AgenciaViewModelTests
         Assert.AreEqual("5208522919307544", codigoBarrasRetorno)
     End Sub
 
+    ' Nesto#359: tests mínimos de AgenciaCanteras. La factory de AgenciasViewModel la invoca
+    ' al seleccionar la agencia, así que como mínimo debe construirse sin crashear, devolver
+    ' "OK" en la llamada al "web service" (sin integración real) y no admitir retorno/cobro
+    ' (Canteras solo entrega; reembolso lo bloquea NestoAPI).
+
+    <TestMethod>
+    Public Sub AgenciaCanteras_Constructor_NoLanzaExcepcion()
+        Dim canteras = New AgenciaCanteras()
+
+        Assert.IsNotNull(canteras.ListaPaises)
+        Assert.IsNotNull(canteras.ListaTiposRetorno)
+        Assert.IsNotNull(canteras.ListaServicios)
+        Assert.IsNotNull(canteras.ListaHorarios)
+    End Sub
+
+    <TestMethod>
+    Public Async Function AgenciaCanteras_LlamadaWebService_DevuelveOkSinIntegracion() As Task
+        Dim canteras = New AgenciaCanteras()
+        Dim respuesta = Await canteras.LlamadaWebService(New EnviosAgencia(), Nothing)
+
+        Assert.IsTrue(respuesta.Exito, "Canteras no integra; debe responder OK para que la máquina de estados avance.")
+        Assert.AreEqual("OK", respuesta.TextoRespuestaError)
+    End Function
+
+    <TestMethod>
+    Public Sub AgenciaCanteras_NoAdmiteRetorno()
+        Dim canteras = New AgenciaCanteras()
+
+        Assert.AreEqual(CByte(0), canteras.retornoObligatorio,
+            "Canteras nunca pide retorno (operativa manual).")
+        Assert.AreEqual(CByte(0), canteras.retornoSinRetorno)
+    End Sub
+
+    <TestMethod>
+    Public Sub AgenciaCanteras_PaisDefecto_EsEspanna()
+        Dim canteras = New AgenciaCanteras()
+
+        Assert.AreEqual(34, canteras.paisDefecto, "Canarias es territorio español; país por defecto = 34.")
+    End Sub
+
 End Class
 


### PR DESCRIPTION
Refs #359 (MVP UI; cierre cuando se complete edición manual del nº envío y flujo de correo a Canteras)

## Summary

Canteras (Numero=11) ya estaba dada de alta en la BD desde antes de este PR, pero al seleccionarla en \`AgenciasViewModel\` el código crasheaba con \`KeyNotFoundException\` porque el factory no la conocía.

- Nueva clase \`Nesto.ViewModels/Agencias/AgenciaCanteras.vb\` con la implementación mínima de \`IAgencia\` (sin integración real, sin etiqueta ZPL, sin retorno, sin contra reembolso). Patrón similar a \`AgenciaOnTime\`.
- Registrada en el factory de \`AgenciasViewModel\`.
- 4 tests mínimos en \`AgenciasViewModelTests\` (constructor, \`LlamadaWebService\`=OK, no retorno, país por defecto España).

Los errores 4xx que devuelve NestoAPI cuando la combinación CEX+Canarias o Canteras+CP no canario o Canteras+reembolso o Canteras sin mínimo de portes se rechazan ya se propagan al usuario vía \`dialogService.ShowError\` en \`DetallePedidoViewModel.CrearEtiquetaPendiente\` (línea 2093). No requiere cambios adicionales — el patrón actual lee \`ex.Message\` directamente, así que el mensaje del backend llega tal cual.

## Fuera de scope (follow-ups para cerrar Nesto#359 del todo)

- **Edición manual del campo CodigoBarras** desde \`Agencias.xaml\`. Hoy la vista no expone ese campo; Canteras lo necesita porque devuelven el nº de envío por correo y hay que pegarlo. Hay que decidir si se habilita el TextBox existente o se crea un campo separado "Nº envío manual".
- **Botón / flujo para enviar el correo a Canteras** desde Nesto al tramitar el envío (hoy no hay automatización; el usuario lo manda a mano).
- (Opcional) Aviso/recordatorio al usuario para que pegue el nº de envío cuando llegue la respuesta de Canteras.

## Test plan

- [x] Build OK del SLN completo.
- [x] 4 tests de \`AgenciaCanteras\` verdes.
- [ ] **Pendiente verificación manual**: en la pestaña de envíos pendientes, seleccionar Canteras en el desplegable → no debe crashear, retorno y reembolso deben quedar a 0. Intentar tramitar con CP no canario → debe mostrar el mensaje de NestoAPI ("La agencia Canteras solo opera en Canarias..."). Tramitar con CP canario e importe < 400€ → mensaje de mínimos.

## Issue enlazada

- Backend: CarlosAdrianM/NestoAPI#204 (MVP en CarlosAdrianM/NestoAPI#209).

🤖 Generated with [Claude Code](https://claude.com/claude-code)